### PR TITLE
Reduce bundle size by 80% and increase speed by 95% (Removes big-integer dep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,11 +1733,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "big-integer": {
-      "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
-    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,5 @@
     "uglify-js": "3.4.9",
     "watchify": "^3.11.1"
   },
-  "dependencies": {
-    "big-integer": "1.6.36"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
When trying to remove dependency bloat internally, we slimmed this library down to only use JS numbers.